### PR TITLE
FIX: Use oneloop-static at link time

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
       - use-avh_olo.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: {{ name }}-static
@@ -50,7 +50,7 @@ outputs:
         - make
         - libtool
       host:
-        - oneloop
+        - oneloop-static
 
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ outputs:
         - {{ compiler('fortran') }}
         - make
         - libtool
+        - oneloop-static  # [build_platform != target_platform]
       host:
         - oneloop-static
 


### PR DESCRIPTION
* Use oneloop-static at link time over oneloop to avoid collisions for mg5amcnlo.
* Add cross-compilation guard support.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
